### PR TITLE
# EDIT - nid 크기를 8바이트로 맞추기위해서 padding -> base64 후 signer에게 리턴하도록 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-    "extends": "airbnb-base"
+    "extends": "airbnb-base",
+    "rules": {
+        "no-param-reassign": "off"
+    }
 };

--- a/enums/types.js
+++ b/enums/types.js
@@ -1,0 +1,3 @@
+module.exports = {
+  SIGNER_ID_TYPE_BYTES_SIZE: 8,
+};

--- a/models/user.js
+++ b/models/user.js
@@ -34,7 +34,6 @@ module.exports = (sequelize, DataTypes) => {
     if (user.role === userRole.SIGNER) {
       if (user.phone === '' || typeof user.phone === 'undefined') throw Sequelize.ValidationError;
       if (user.publicKey === '' || typeof user.publicKey === 'undefined') throw Sequelize.ValidationError;
-      if (user.cert === '' || typeof user.cert === 'undefined') throw Sequelize.ValidationError;
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1096,6 +1096,11 @@
         "which": "^1.2.9"
       }
     },
+    "crypto-random": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/crypto-random/-/crypto-random-1.0.3.tgz",
+      "integrity": "sha1-wEF50c1kOfW1GhmZcnnyTdtIwgg="
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "chai-http": "^4.2.0",
     "cookie-parser": "~1.4.3",
     "cross-env": "^5.2.0",
+    "crypto-random": "^1.0.3",
     "debug": "~2.6.9",
     "dotenv": "^6.1.0",
     "eslint-config-airbnb": "^17.1.0",

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -5,6 +5,7 @@ const forge = require('node-forge');
 const router = express.Router();
 const { User } = require('../models');
 const cert = require('../utils/cert');
+const converter = require('../utils/type_converter');
 const userRole = require('../enums/user_role');
 
 router.post('/users', bodyParser.urlencoded({ extended: false }), async (req, res) => {
@@ -23,7 +24,7 @@ router.post('/users', bodyParser.urlencoded({ extended: false }), async (req, re
     });
 
     if (!user) {
-      user = await User.build({ phone, publicKey: pemPublicKey, role: userRole.SIGNER });
+      user = await User.create({ phone, publicKey: pemPublicKey, role: userRole.SIGNER });
       const pem = await cert.getCert({ nid: user.nid, csr: subjectCsr });
       user.cert = pem;
       await user.save();
@@ -31,7 +32,7 @@ router.post('/users', bodyParser.urlencoded({ extended: false }), async (req, re
       return res.status(200).json({
         code: 200,
         message: '유저가 등록되었습니다.',
-        nid: user.nid,
+        nid: converter.nIdToBase64Str(user.nid),
         pem,
       });
     }
@@ -39,7 +40,7 @@ router.post('/users', bodyParser.urlencoded({ extended: false }), async (req, re
     return res.status(200).json({
       code: 200,
       message: '유저가 이미 존재합니다.',
-      nid: user.nid,
+      nid: converter.nIdToBase64Str(user.nid),
     });
   } catch (err) {
     // TODO: logger로 대체해야 함

--- a/test/models/user.js
+++ b/test/models/user.js
@@ -3,9 +3,12 @@ process.env.NODE_ENV = 'test';
 const { expect } = require('chai');
 const { User } = require('../../models');
 const userRole = require('../../enums/user_role');
+const Cert = require('../../utils/cert');
 
 /* eslint-disable no-undef */
 describe('User', () => {
+  Cert.generateKeyPair();
+
   const publicKey = '-----BEGIN PUBLIC KEY-----\n'
     + '\n'
     + ' MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0\n'
@@ -55,6 +58,8 @@ describe('User', () => {
       }).then((user) => {
         expect(user.phone).to.equal('010-1234-5678');
         done();
+      }).catch((err) => {
+        done(err);
       });
     });
 
@@ -75,18 +80,6 @@ describe('User', () => {
         phone: '010-8770-6498',
         role: userRole.SIGNER,
         publicKey: '',
-      }).catch((err) => {
-        expect(err.name).to.equal('ValidationError');
-        done();
-      });
-    });
-
-    it('should not create user if cert is empty', (done) => {
-      User.create({
-        phone: '010-8770-6498',
-        role: userRole.SIGNER,
-        publicKey,
-        cert: '',
       }).catch((err) => {
         expect(err.name).to.equal('ValidationError');
         done();

--- a/test/routes/v1.js
+++ b/test/routes/v1.js
@@ -12,6 +12,7 @@ const should = chai.should();
 const { expect } = chai;
 const server = require('../../app.js');
 const { User, Key } = require('../../models');
+const Cert = require('../../utils/cert');
 
 chai.use(chaiHttp);
 
@@ -106,6 +107,8 @@ describe('POST users', function () {
   });
 
   it('expect to have valid certificate data', (done) => {
+    Cert.generateKeyPair();
+
     chai.request(server)
       .post('/v1/users')
       .send({

--- a/test/utils/type_converter.js
+++ b/test/utils/type_converter.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-unused-expressions */
+process.env.NODE_ENV = 'test';
+
+const { expect } = require('chai');
+const converter = require('../../utils/type_converter');
+
+/* eslint-disable no-undef */
+describe('TypeConverter', () => {
+  describe('#nIdToBase64Str', () => {
+    it('should generate key pairs', (done) => {
+      const encodedStr = converter.nIdToBase64Str(20000);
+      const len = Buffer.byteLength(encodedStr, 'base64');
+
+      expect(len).to.equals(8);
+      expect(encodedStr).to.equals('MDAwMjAwMDA=');
+
+      const b64String = Buffer.from(encodedStr, 'base64').toString();
+      expect(b64String).to.equals('00020000');
+      done();
+    });
+  });
+});

--- a/utils/type_converter.js
+++ b/utils/type_converter.js
@@ -1,0 +1,13 @@
+const types = require('../enums/types');
+
+class TypeConverter {
+  static nIdToBase64Str(nid) {
+    const nidString = nid.toString();
+    const paddedStr = nidString.padStart(types.SIGNER_ID_TYPE_BYTES_SIZE, '0');
+
+    const tmpBuffer = Buffer.from(paddedStr);
+    return tmpBuffer.toString('base64');
+  }
+}
+
+module.exports = TypeConverter;


### PR DESCRIPTION
## 수정사항
- 종전의 코드에서는 단순히 nid를 signer에게 리턴해주었다. 설계서대로 8bytes를 맞춰서 보내줘야 하므로, decimal을 string으로 변환후 padding한다. 그리고 base64 인코딩해서 signer에게 보내준다.
- `nIdToBase64Str`가 nid를 base64로 인코딩하는 함수

## ETC
- travis 설정이 안되어있어서 설정후 test 코드 fail 되는 것 수정