### PR TITLE
# EDIT - Signer가 네트워크에 참가할때 이미 등록되었는지 여부 검사

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -14,10 +14,10 @@ router.post('/users', bodyParser.urlencoded({ extended: false }), async (req, re
 
     const subjectCsr = cryptoUtils.asn1.csr.CSRUtil.getInfo(csr);
     const pemPublicKey = cryptoUtils.asn1.ASN1Util.getPEMStringFromHex(subjectCsr.pubkey.hex, 'PUBLIC KEY');
+
     let user = await User.findOne({
       where: {
         phone,
-        publicKey: pemPublicKey,
       },
       attributes: ['nid'],
     });


### PR DESCRIPTION

## 수정사항
- 이미 등록되어있는지 검사하기 위해 전화번호와 csr값으로 검사하고 있다.
- 하지만 CSR은 매 요청마다 값이 다르기 때문에 같은 유저라고 하더라도 매번 다른 유저로 인식된다.
- phone 번호만 검사해서 인증서 발급하도록 수정